### PR TITLE
manually add prefix to docs url in app.py

### DIFF
--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -162,7 +162,7 @@ async def lifespan(app: FastAPI):
 api = StacApi(
     app=FastAPI(
         openapi_url=settings.openapi_url,
-        docs_url=settings.docs_url,
+        docs_url=settings.prefix_path + settings.docs_url,
         redoc_url=None,
         root_path=settings.root_path,
         title=settings.stac_fastapi_title,


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**
The "docs_url" is set in the "stac-fastapi" repo, upstream from the "stac-fastapi-pgstac" repo. It does not take a "prefix_path" vairable. In order for the "prefix_path" variable to be added to the "docs_url", we need to add it manually.

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
